### PR TITLE
Return base AP url in unauthorized response from protected resources

### DIFF
--- a/config.dist.js
+++ b/config.dist.js
@@ -16,7 +16,8 @@ exports.db = {
 };
 
 exports.uris = {
-  authorization_uri: "http://example.com/authorized"
+  authorization_uri: "http://ap.example.com/authorized",
+  authorization_provider_base_uri: "http://ap.example.com"
 };
 
 exports.service_provider_id = process.env.SERVICE_PROVIDER_ID || '1';

--- a/config.test.js
+++ b/config.test.js
@@ -15,7 +15,8 @@ exports.db = {
 };
 
 exports.uris = {
-  authorization_uri: "http://example.com/authorized"
+  authorization_uri: "http://ap.example.com/authorized",
+  authorization_provider_base_uri: "http://ap.example.com"
 };
 
 exports.service_provider_id = '1';

--- a/lib/protected-resource-handler.js
+++ b/lib/protected-resource-handler.js
@@ -70,7 +70,7 @@ module.exports = function(config, db, logger) {
   var sendUnauthorizedResponse = function(res) {
     res.json(401, {
       error: 'unauthorized',
-      authorization_uri: config.uris.authorization_uri,
+      authorization_uri: config.uris.authorization_provider_base_uri,
       service_provider_id: config.service_provider_id
     });
   };

--- a/test/lib/resource-test.js
+++ b/test/lib/resource-test.js
@@ -374,7 +374,7 @@ describe("Accessing a protected resource", function() {
     describe("the response body", function() {
       it("should include the authorization uri", function() {
         expect(this.res.body).to.have.property('authorization_uri');
-        expect(this.res.body.authorization_uri).to.equal('http://example.com/authorized');
+        expect(this.res.body.authorization_uri).to.equal('http://ap.example.com');
       });
 
       it("should include the service provider id", function() {


### PR DESCRIPTION
This is a temporary change in response to this issue: https://github.com/ebu/cpa-spec/issues/10.
