### PR TITLE
Use WWW-Authenticate header to return AP info

### DIFF
--- a/config.dist.js
+++ b/config.dist.js
@@ -15,9 +15,11 @@ exports.db = {
   debug: true
 };
 
-exports.uris = {
-  authorization_uri: "http://ap.example.com/authorized",
-  authorization_provider_base_uri: "http://ap.example.com"
+exports.authorization_provider = {
+  name:              "Example AP",
+  authorization_uri: "https://ap.example.com/authorized",
+  base_uri:          "https://ap.example.com",
+  modes:             ["client", "user"]
 };
 
 exports.service_provider_id = process.env.SERVICE_PROVIDER_ID || 'STATION_NAME';

--- a/config.test.js
+++ b/config.test.js
@@ -10,9 +10,11 @@ exports.db = {
   debug: false
 };
 
-exports.uris = {
-  authorization_uri: "http://ap.example.com/authorized",
-  authorization_provider_base_uri: "http://ap.example.com"
+exports.authorization_provider = {
+  name:              "Example AP",
+  authorization_uri: "https://ap.example.com/authorized",
+  base_uri:          "https://ap.example.com",
+  modes:             ["client", "user"]
 };
 
 exports.service_provider_id = 'BBC1';

--- a/lib/protected-resource-handler.js
+++ b/lib/protected-resource-handler.js
@@ -50,7 +50,7 @@ module.exports = function(config, db, logger) {
 
   var checkIsAuthorized = function(accessToken, callback) {
     var requestOptions = {
-      uri:  config.uris.authorization_uri,
+      uri:  config.authorization_provider.authorization_uri,
       form: {
         token:               accessToken,
         service_provider_id: config.service_provider_id
@@ -90,12 +90,19 @@ module.exports = function(config, db, logger) {
     });
   };
 
+  var quote = function(string) {
+    return '"' + string + '"';
+  };
+
   var sendUnauthorizedResponse = function(res) {
-    res.json(401, {
-      error:               'unauthorized',
-      authorization_uri:   config.uris.authorization_provider_base_uri,
-      service_provider_id: config.service_provider_id
-    });
+    var headerValue = "CPA " + [
+      "name="  + quote(config.authorization_provider.name),
+      "uri="   + quote(config.authorization_provider.base_uri),
+      "modes=" + quote(config.authorization_provider.modes.join(","))
+    ].join(" ");
+
+    res.set('WWW-Authenticate', headerValue);
+    res.send(401, "");
   };
 
   var createUser = function(state, callback) {

--- a/test/lib/resource-test.js
+++ b/test/lib/resource-test.js
@@ -42,7 +42,7 @@ describe("Accessing a protected resource", function() {
       before(function(done) {
         var config = app.get('config');
 
-        nock(config.uris.authorization_uri)
+        nock(config.authorization_provider.base_uri)
           .post('/authorized')
           .reply(200, { client_id: 11, user_id: 12 });
 
@@ -113,7 +113,7 @@ describe("Accessing a protected resource", function() {
       before(function(done) {
         var config = app.get('config');
 
-        nock(config.uris.authorization_uri)
+        nock(config.authorization_provider.base_uri)
           .post('/authorized')
           .reply(200, { client_id: 11, user_id: 12 });
 
@@ -183,7 +183,7 @@ describe("Accessing a protected resource", function() {
       before(function(done) {
         var config = app.get('config');
 
-        nock(config.uris.authorization_uri)
+        nock(config.authorization_provider.base_uri)
           .post('/authorized')
           .reply(200, { client_id: 11, user_id: null });
 
@@ -247,7 +247,7 @@ describe("Accessing a protected resource", function() {
       before(function(done) {
         var config = app.get('config');
 
-        nock(config.uris.authorization_uri)
+        nock(config.authorization_provider.base_uri)
           .post('/authorized')
           .reply(200, { client_id: 11, user_id: 13 });
 
@@ -317,8 +317,19 @@ describe("Accessing a protected resource", function() {
       requestHelper.sendRequest(this, '/resource', { accessToken: null }, done);
     });
 
-    it("should return an 'unauthorized' error", function() {
-      assertions.verifyError(this.res, 401, 'unauthorized');
+    it("should return status 401", function() {
+      expect(this.res.statusCode).to.equal(401);
+    });
+
+    // jshint expr:true
+    it("should return a www-authenticate header", function() {
+      expect(this.res.headers['www-authenticate']).to.equal('CPA name="Example AP" uri="https://ap.example.com" modes="client,user"');
+    });
+
+    // jshint expr:true
+    it("should return an empty response body", function() {
+      // expect(this.res.text).to.be.equal("");
+      expect(this.res.text).to.be.empty;
     });
   });
 
@@ -326,27 +337,21 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(401);
 
       requestHelper.sendRequest(this, '/resource', { accessToken: 'abc123' }, done);
     });
 
-    it("should return an unauthorized error", function() {
-      assertions.verifyError(this.res, 401, 'unauthorized');
+    // jshint expr:true
+    it("should return a www-authenticate header", function() {
+      expect(this.res.headers['www-authenticate']).to.equal('CPA name="Example AP" uri="https://ap.example.com" modes="client,user"');
     });
 
-    describe("the response body", function() {
-      it("should include the authorization uri", function() {
-        expect(this.res.body).to.have.property('authorization_uri');
-        expect(this.res.body.authorization_uri).to.equal('http://ap.example.com');
-      });
-
-      it("should include the service provider id", function() {
-        expect(this.res.body).to.have.property('service_provider_id');
-        expect(this.res.body.service_provider_id).to.equal('BBC1');
-      });
+    // jshint expr:true
+    it("should return an empty response body", function() {
+      expect(this.res.text).to.be.empty;
     });
   });
 
@@ -367,7 +372,7 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(500);
 
@@ -385,7 +390,7 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { client_id: null, user_id: null });
 
@@ -403,7 +408,7 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { client_id: 'invalid', user_id: null });
 
@@ -421,7 +426,7 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { client_id: 11, user_id: 'invalid' });
 
@@ -439,7 +444,7 @@ describe("Accessing a protected resource", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, "invalid");
 

--- a/test/lib/tag-test.js
+++ b/test/lib/tag-test.js
@@ -85,7 +85,7 @@ describe("GET /tags", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { client_id: 11, user_id: 12 });
 
@@ -220,15 +220,21 @@ describe("GET /tags", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(401);
 
       requestHelper.sendRequest(this, '/tags', { accessToken: '456def' }, done);
     });
 
-    it("should return an 'unauthorized' error", function() {
-      assertions.verifyError(this.res, 401, 'unauthorized');
+    // jshint expr:true
+    it("should return a www-authenticate header", function() {
+      expect(this.res.headers['www-authenticate']).to.equal('CPA name="Example AP" uri="https://ap.example.com" modes="client,user"');
+    });
+
+    // jshint expr:true
+    it("should return an empty response body", function() {
+      expect(this.res.text).to.be.empty;
     });
   });
 });
@@ -240,7 +246,7 @@ describe("POST /tag", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { user_id: 11, client_id: 12 });
 
@@ -407,7 +413,7 @@ describe("POST /tag", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { user_id: 11, client_id: 12 });
 
@@ -434,7 +440,7 @@ describe("POST /tag", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { user_id: 11, client_id: 12 });
 
@@ -461,7 +467,7 @@ describe("POST /tag", function() {
     before(function(done) {
       var config = app.get('config');
 
-      nock(config.uris.authorization_uri)
+      nock(config.authorization_provider.base_uri)
         .post('/authorized')
         .reply(200, { user_id: 11, client_id: 12 });
 


### PR DESCRIPTION
This change returns AP info in a WWW-Authenticate header, in 401 responses to protected resources.
