### PR TITLE
URL prefix

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -2,7 +2,6 @@
 
 "use strict";
 
-var app     = require('../lib/app');
 var version = require('../package.json').version;
 
 var http  = require('http');
@@ -23,6 +22,11 @@ var argv = yargs
       alias: "p",
       description: "<number> HTTP server port (default: " + DEFAULT_PORT + ")",
       requiresArg: true
+    },
+    "config-file": { // yargs doesn't allow us to have an option named 'config'.
+      alias: "c",
+      description: "<filename> Config file name",
+      requiresArg: true
     }
   })
   .strict()
@@ -33,6 +37,15 @@ var argv = yargs
     }
   })
   .argv;
+
+var configFilename = require('../lib/config-filename');
+
+if (argv["config-file"]) {
+  configFilename.configFilename = argv["config-file"];
+}
+
+// Start the server
+var app = require('../lib/app');
 
 app.set('port', argv.port || process.env.PORT || DEFAULT_PORT);
 

--- a/config.dist.js
+++ b/config.dist.js
@@ -40,6 +40,6 @@ module.exports = {
     ]
   },
 
-  // URL path namespace prefix
-  namespace: '/sp'
+  // URL path namespace prefix, e.g., '/sp'
+  namespace: ''
 };

--- a/config.dist.js
+++ b/config.dist.js
@@ -38,5 +38,8 @@ module.exports = {
     allowed_domains: [
       "http://cpa-client.ebu.io"
     ]
-  }
+  },
+
+  // URL path namespace prefix
+  namespace: '/sp'
 };

--- a/config.dist.js
+++ b/config.dist.js
@@ -40,6 +40,6 @@ module.exports = {
     ]
   },
 
-  // URL path namespace prefix, e.g., '/sp'
-  namespace: ''
+  // URL path prefix, e.g., '/myapp'
+  urlPrefix: ''
 };

--- a/config.js
+++ b/config.js
@@ -1,7 +1,17 @@
 "use strict";
 
-if(process.env.NODE_ENV === 'test') {
-  module.exports = require('./config.test');
-} else {
-  module.exports = require('./config.local');
+var configFilename = require('./lib/config-filename');
+
+var filename;
+
+if (configFilename.configFilename) {
+  filename = configFilename.configFilename;
 }
+else if (process.env.NODE_ENV === 'test') {
+  filename = './config.test';
+}
+else {
+  filename = './config.local';
+}
+
+module.exports = require(filename);

--- a/config.test.js
+++ b/config.test.js
@@ -24,5 +24,8 @@ module.exports = {
   service_provider: {
     name:   "BBC1",
     domain: "sp.example.com"
-  }
+  },
+
+  // URL path namespace prefix
+  namespace: '/sp'
 };

--- a/config.test.js
+++ b/config.test.js
@@ -26,6 +26,6 @@ module.exports = {
     domain: "sp.example.com"
   },
 
-  // URL path namespace prefix
-  namespace: '/sp'
+  // URL path namespace prefix, e.g., '/sp'
+  namespace: ''
 };

--- a/config.test.js
+++ b/config.test.js
@@ -26,6 +26,6 @@ module.exports = {
     domain: "sp.example.com"
   },
 
-  // URL path namespace prefix, e.g., '/sp'
-  namespace: ''
+  // URL path prefix, e.g., '/myapp'
+  urlPrefix: ''
 };

--- a/lib/app.js
+++ b/lib/app.js
@@ -2,7 +2,9 @@
 
 // Module dependencies
 var express = require('express');
-var path    = require('path');
+require('express-namespace');
+
+var path = require('path');
 
 var config = require('../config.js');
 var db     = require('../models');
@@ -49,12 +51,17 @@ app.use(express.urlencoded());
 
 // Routes
 app.use(app.router);
-app.use(express.static(path.join(__dirname, '..', 'public')));
 
-require('../routes/status')(app);
-require('../routes/resource')(app);
-require('../routes/index')(app);
-require('../routes/tags')(app);
+var urlPrefix = config.namespace || '';
+
+app.use(urlPrefix, express.static(path.join(__dirname, '..', 'public')));
+
+app.namespace(urlPrefix, function() {
+  require('../routes/status')(app);
+  require('../routes/resource')(app);
+  require('../routes/index')(app);
+  require('../routes/tags')(app);
+});
 
 if (app.get('env') !== 'test') {
   app.use(express.errorHandler());

--- a/lib/app.js
+++ b/lib/app.js
@@ -52,7 +52,7 @@ app.use(express.urlencoded());
 // Routes
 app.use(app.router);
 
-var urlPrefix = config.namespace || '';
+var urlPrefix = config.urlPrefix || '';
 
 app.use(urlPrefix, express.static(path.join(__dirname, '..', 'public')));
 

--- a/lib/config-filename.js
+++ b/lib/config-filename.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = {
+  configFilename: ''
+};

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "node-uuid": "~1.4.1",
     "async": "~0.2.10",
     "yargs": "~1.3.1",
-    "cors": "~2.4.2"
+    "cors": "~2.4.2",
+    "express-namespace": "~0.1.1"
   },
   "devDependencies": {
     "supertest": "~0.8.2",

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -2,12 +2,17 @@
 
 var db = require('../../models');
 
+var requestHelper = require('../request-helper');
+var config = require('../../config');
+
 /**
- * Global test setup, run before any individual tests are run. This
- * creates the schema in the in-memory SQLite database.
+ * Global test setup, run before any individual tests are run. This creates the
+ * schema in the in-memory SQLite database and sets the URL path prefix.
  */
 
 before(function(done) {
+  requestHelper.namespace = config.namespace;
+
   db.sequelize.sync({ force: true }).complete(function(err) {
     done(err);
   });

--- a/test/lib/setup.js
+++ b/test/lib/setup.js
@@ -11,7 +11,7 @@ var config = require('../../config');
  */
 
 before(function(done) {
-  requestHelper.namespace = config.namespace;
+  requestHelper.urlPrefix = config.urlPrefix;
 
   db.sequelize.sync({ force: true }).complete(function(err) {
     done(err);

--- a/test/lib/static-resource-test.js
+++ b/test/lib/static-resource-test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+var requestHelper = require('../request-helper');
+
+describe('Static resources', function() {
+
+  var resources = ['/js/jquery.js', '/css/bootstrap.css', '/js/bootstrap.js'];
+
+  resources.forEach(function(resourcePath) {
+    beforeEach(function(done) {
+      requestHelper.sendRequest(this, resourcePath, null, done);
+    });
+
+    it('should successfully return ' + resourcePath + ' with status 200', function() {
+      expect(this.res.statusCode).to.equal(200);
+    });
+  });
+});

--- a/test/request-helper.js
+++ b/test/request-helper.js
@@ -4,6 +4,8 @@ var cheerio = require('cheerio');
 
 module.exports = {
 
+  namespace: '',
+
   /**
    * Helper function for making HTTP requests and handling responses.
    *
@@ -30,6 +32,8 @@ module.exports = {
 
   sendRequest: function(context, path, opts, done) {
     opts = opts || {};
+
+    path = this.namespace + path;
 
     var method = opts.method || 'get';
 

--- a/test/request-helper.js
+++ b/test/request-helper.js
@@ -4,7 +4,7 @@ var cheerio = require('cheerio');
 
 module.exports = {
 
-  namespace: '',
+  urlPrefix: '',
 
   /**
    * Helper function for making HTTP requests and handling responses.
@@ -33,7 +33,7 @@ module.exports = {
   sendRequest: function(context, path, opts, done) {
     opts = opts || {};
 
-    path = this.namespace + path;
+    path = this.urlPrefix + path;
 
     var method = opts.method || 'get';
 

--- a/views/layout/head.ejs
+++ b/views/layout/head.ejs
@@ -4,7 +4,7 @@
   <title>Cross-Platform Authentication - Service Provider</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <!-- Bootstrap -->
-  <link href="/css/bootstrap.min.css" rel="stylesheet">
+  <link href="css/bootstrap.min.css" rel="stylesheet">
 
   <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
   <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->


### PR DESCRIPTION
This change adds a `urlPrefix` config option that allows the auth provider's base URL to be set so that, for example, https://example.com/tag could be changed to https://example.com/sp/tag. Also added are a few helper functions for constructing URLs. 
